### PR TITLE
Add gzip to api gateway if the request supports it

### DIFF
--- a/lambda_utils/response_handlers/api_gateway.py
+++ b/lambda_utils/response_handlers/api_gateway.py
@@ -1,12 +1,21 @@
 from lambda_utils.response_handlers import BaseResponseHandler
 from concurrent.futures import TimeoutError
+from cStringIO import StringIO
+import gzip
 import json
 import urlparse
 
 
 class ApiGateway(BaseResponseHandler):
+    gzip_response = None
+    event = []
+
+    def __init__(self, gzip_response=True):
+        self.gzip_response = gzip_response
+
     def on_execution(self, event):
         event['body'] = extract_body(event)
+        self.event = event
         return event
 
     def on_exception(self, ex):
@@ -14,6 +23,30 @@ class ApiGateway(BaseResponseHandler):
             return http_response("Execution is about to timeout.", status=504)
         else:
             return http_response('Internal Server Error', status=500)
+
+    def on_response(self, response):
+        response = self._gzip_if_possible(response)
+
+        return response
+
+    def _gzip_if_possible(self, response):
+        accecpted_encoding = self.event.get('headers', {}).get('Accept-Encoding', '')
+        if 'gzip' not in accecpted_encoding.lower():
+            return response
+
+        if response['statusCode'] < 200 or response['statusCode'] >= 300 or 'Content-Encoding' in response['headers']:
+            return response
+
+        gzip_buffer = StringIO()
+        gzip_file = gzip.GzipFile(mode='wb', fileobj=gzip_buffer)
+        gzip_file.write(response.get('body'))
+        gzip_file.close()
+
+        response['body'] = gzip_buffer.getvalue()
+        response['headers']['Content-Encoding'] = 'gzip'
+        response['headers']['Vary'] = 'Accept-Encoding'
+        response['headers']['Content-Length'] = len(response['body'])
+        return response
 
 
 def http_response(body, status=200, headers=None):

--- a/tests/response_handlers/test_api_gateway.py
+++ b/tests/response_handlers/test_api_gateway.py
@@ -1,8 +1,10 @@
-from hamcrest import equal_to, assert_that, has_entry
-from mock import patch
-from lambda_utils.response_handlers import api_gateway as module
-from lambda_utils.response_handlers.api_gateway import ApiGateway, extract_body, http_response, json_http_response, redirect_to
 from concurrent.futures import TimeoutError
+from hamcrest import assert_that, equal_to, has_entry, less_than
+from mock import patch
+
+from lambda_utils.response_handlers import api_gateway as module
+from lambda_utils.response_handlers.api_gateway import ApiGateway, extract_body, http_response, \
+    json_http_response, redirect_to
 
 
 class TestApiGateway:
@@ -26,6 +28,49 @@ class TestApiGateway:
 
         assert_that(result['statusCode'], equal_to(500))
         assert_that(result['body'], equal_to('Internal Server Error'))
+
+    def test_on_response_returns_uncompressed_response_unsupported_request(self):
+        response = http_response('something')
+        api_gateway = ApiGateway()
+        api_gateway.event = {'headers': {'Accept-Encoding': 'deflate, br'}}
+
+        result = api_gateway.on_response(response)
+
+        assert_that(result, equal_to(response))
+
+    def test_on_response_returns_uncompressed_response_unsupported_status_code(self):
+        response = http_response('something', status=301)
+        api_gateway = ApiGateway()
+        api_gateway.event = {'headers': {'Accept-Encoding': 'gzip, deflate, br'}}
+
+        result = api_gateway.on_response(response)
+
+        assert_that(result, equal_to(response))
+
+    def test_on_response_returns_compressed_response(self):
+        body = """{
+            "city": "Munich",
+            "country_code": "DE",
+            "country_name": "Germany",
+            "latitude": 48.15,
+            "longitude": 11.5833,
+            "postal_code": "80798"
+        }"""
+        response = http_response(str(body))
+        api_gateway = ApiGateway()
+        api_gateway.event = {'headers': {'Accept-Encoding': 'gzip, deflate, br'}}
+
+        result = api_gateway.on_response(response)
+
+        assert_that(len(result['body']), less_than(len(body)))
+        assert_that(
+            result['headers'], equal_to({
+                'Access-Control-Allow-Origin': '*',
+                'Vary': 'Accept-Encoding',
+                'Content-Length': 29,
+                'Content-Encoding': 'gzip'
+            })
+        )
 
 
 class TestExtractBody:

--- a/tests/response_handlers/test_api_gateway.py
+++ b/tests/response_handlers/test_api_gateway.py
@@ -67,7 +67,7 @@ class TestApiGateway:
             result['headers'], equal_to({
                 'Access-Control-Allow-Origin': '*',
                 'Vary': 'Accept-Encoding',
-                'Content-Length': 29,
+                'Content-Length': 121,
                 'Content-Encoding': 'gzip'
             })
         )


### PR DESCRIPTION
This pr should enable gzip on a lambda function when the api gateway response handler is used and the requester support the gzip compression